### PR TITLE
Merge completed words on subscription update

### DIFF
--- a/src/pages/[roomId].js
+++ b/src/pages/[roomId].js
@@ -34,8 +34,24 @@ const GameRoom = ({ quote }) => {
             stage() {
               return stage;
             },
-            players() {
-              return players;
+            players(cachedPlayers) {
+              return players.map((newPlayer) => {
+                const cachedPlayer = cachedPlayers.find(
+                  (p) => p.id === newPlayer.id
+                );
+
+                if (!cachedPlayer) return newPlayer;
+
+                return {
+                  ...newPlayer,
+                  completedWords: [
+                    ...new Set([
+                      ...cachedPlayer.completedWords,
+                      ...newPlayer.completedWords,
+                    ]),
+                  ],
+                };
+              });
             },
           },
         });


### PR DESCRIPTION
There is a bug where if you guess two words really quickly, it show it as completed (due to the completeWord `cache.modify`), then disappear (when the subscription update for the first word occurs), then reappear (when the subscription update for the second word occurs). To prevent this flash, subscription updates will merge together guessed words to ensure that completed words are never lost.